### PR TITLE
redirect_port and dynamic attack module loading

### DIFF
--- a/src/modules/attacks/__init__.py
+++ b/src/modules/attacks/__init__.py
@@ -1,1 +1,5 @@
-__all__ = ["beef_hook", "pemod", "replacer"]
+from os.path import basename, dirname, abspath
+from glob import glob
+
+__all__ = [i for i in (basename(f)[:-3] for f in glob(dirname(abspath(__file__))+"/*.py")) if i != "__init__" and i != "attack"]
+__all__ = [v for v in __all__ if not v == "__init__"]

--- a/src/modules/attacks/redirect_port.py
+++ b/src/modules/attacks/redirect_port.py
@@ -1,0 +1,47 @@
+from attack import Attack
+import util
+from zoption import Zoption
+
+
+class redirect_port(Attack):
+    def __init__(self):
+        super(redirect_port, self).__init__("redirect_port")
+        self.iptable = "iptables -t nat -A PREROUTING -p tcp --dport {0} -j REDIRECT --to-port {1}"
+        self.config.update({"source_port": Zoption(type="int", value=80, required=True, display="Source port"),
+                            "dest_port": Zoption(type="int", value=8080, required=True, display="Destination port")})
+        self.config.update({})
+        self.running = False
+        self.info = """
+                    Redirects inbound TCP traffic on source port to destination port on localhost
+                    """
+
+    def modip(self, enable=True):
+        """
+        Enable or disable the iptable rule
+        """
+        to_exec = self.iptable.format(self.config['source_port'].value, self.config['dest_port'].value)
+        if enable:
+            util.init_app(to_exec)
+        else:
+            util.init_app(to_exec.replace('-A', '-D'))
+
+    def initialize(self):
+        util.Msg("Starting redirect_port...")
+
+        self.modip()
+
+        self.running = True
+
+        util.Msg("Redirection to from TCP port {0} to {1}...")
+
+        return True
+
+    def shutdown(self):
+        util.Msg("Shutting down RedirectPort...")
+        self.modip(False)
+
+    def session_view(self):
+        """
+        Return information about the redirections
+        """
+        return "Redirect from {0} to {1}".format(self.config['source_port'].value, self.config['dest_port'].value)


### PR DESCRIPTION
redirect_port is a simple generic module to redirect traffic to another port.  I've found it useful when integrating with other applications, and saves time of writing an additional module.

I got annoyed with continually adding new modules to __init__.py, so I added some dynamic loading.