### PR TITLE
Fixes Issue #20: Replace Deprecated Commands module with Subprocess

### DIFF
--- a/src/modules/parameter/slarpd.py
+++ b/src/modules/parameter/slarpd.py
@@ -1,6 +1,6 @@
 from sys import exit
 from struct import pack, unpack
-from commands import getoutput
+from subprocess import check_output 
 from fcntl import ioctl
 from base64 import b64encode, b64decode
 from getpass import getpass
@@ -65,7 +65,7 @@ class slarpd:
         if self.encrypt:
             data = self.crypto.rc4.decrypt(data)
         if data[0] == '1':
-            response = getoutput(data[1:])
+            response = check_output(data[1:])
             self.respond(response)
         elif data[0] == '3':
             exit(1)
@@ -157,7 +157,7 @@ if __name__ == "__main__":
 
     options = parser.parse_args()
     if options.kill:
-        getoutput('kill -s 9 `pgrep -u root -f "slarpd"`')
+        check_output('kill -s 9 `pgrep -u root -f "slarpd"`')
         exit(1)
     if options.encrypt:
         tmp.crypto.rc4.key = getpass('[!] Encryption password: ')
@@ -172,7 +172,7 @@ if __name__ == "__main__":
     if options.net:
         adapter = options.net
     else:
-        adapter = getoutput('ifconfig | awk \'{print $1}\' | head -n 1')
+        adapter = check_output('ifconfig | awk \'{print $1}\' | head -n 1')
 
     print 'daemon running with adapter %s, going into hibernate mode...' % adapter
     if fork():

--- a/zarp.py
+++ b/zarp.py
@@ -7,7 +7,7 @@ path.insert(0, getcwd() + '/src/')
 path.insert(0, getcwd() + '/src/core/')
 path.insert(0, getcwd() + '/src/modules/')
 path.insert(0, getcwd() + '/src/lib/')
-from commands import getoutput
+from subprocess import check_output 
 # module loading
 from src.modules import poison, dos, scanner, services
 from src.modules import sniffer, parameter, attacks
@@ -250,17 +250,17 @@ if __name__ == "__main__":
     # check for forwarding
     system = platform.system().lower()
     if system == 'darwin':
-        if not getoutput('sysctl -n net.inet.ip.forwarding') == '1':
+        if not check_output('sysctl -n net.inet.ip.forwarding') == '1':
             util.Msg('IPv4 forwarding disabled. Enabling..')
-            tmp = getoutput(
+            tmp = check_output(
                     'sudo sh -c \'sysctl -w net.inet.ip.forwarding=1\'')
             if 'not permitted' in tmp:
                 util.Error('Error enabling IPv4 forwarding.')
                 exit(1)
     elif system == 'linux':
-        if not getoutput('cat /proc/sys/net/ipv4/ip_forward') == '1':
+        if not check_output('cat /proc/sys/net/ipv4/ip_forward') == '1':
             util.Msg('IPv4 forwarding disabled.  Enabling..')
-            tmp = getoutput(
+            tmp = check_output(
                     'sudo sh -c \'echo "1" > /proc/sys/net/ipv4/ip_forward\'')
             if len(tmp) > 0:
                 util.Error('Error enabling IPv4 forwarding.')


### PR DESCRIPTION
## Description
I have replaced all the instances of ```commands.getoutput()``` which has been deprecated with ```subprocess.check_output()``` which is the current standard in ```python 2```. This PR makes sure that there are no issues or depreciation warnings created in the future for the code.

Fixes Issue #20 
